### PR TITLE
Added Support for .NET 4.0

### DIFF
--- a/EPPlusEnumerable/EPPlusEnumerable.csproj
+++ b/EPPlusEnumerable/EPPlusEnumerable.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EPPlusEnumerable</RootNamespace>
     <AssemblyName>EPPlusEnumerable</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">.\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -47,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions.cs" />
     <Compile Include="Spreadsheet.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SpreadsheetTabNameAttribute.cs" />

--- a/EPPlusEnumerable/Extensions.cs
+++ b/EPPlusEnumerable/Extensions.cs
@@ -1,0 +1,23 @@
+﻿namespace EPPlusEnumerable
+{
+    using System;
+    using System.Reflection;
+
+    internal static class Extensions
+    {
+        public static T GetCustomAttribute<T>(this MemberInfo element, bool inherit) where T : Attribute
+        {
+            return (T)Attribute.GetCustomAttribute(element, typeof(T), inherit);
+        }
+
+        public static T GetCustomAttribute<T>(this MemberInfo element) where T : Attribute
+        {
+            return (T)Attribute.GetCustomAttribute(element, typeof(T));
+        }
+
+        public static object GetValue(this PropertyInfo element, Object obj)
+        {
+            return element.GetValue(obj, BindingFlags.Default, null, null, null);
+        }
+    }
+}


### PR DESCRIPTION
As I said in Issue #7 , we can target a lower version of .NET.

This PR allows for that support without changing any of EPPlusEnumerable core code.