### PR TITLE
ExcludeFromOutput and small refactorings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+/EPPlusEnumerable.sln.GhostDoc.xml

--- a/EPPlusEnumerable.Tests/EPPlusEnumerable.Tests.csproj
+++ b/EPPlusEnumerable.Tests/EPPlusEnumerable.Tests.csproj
@@ -80,15 +80,6 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EPPlusEnumerable.sln
+++ b/EPPlusEnumerable.sln
@@ -1,16 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EPPlusEnumerable", "EPPlusEnumerable\EPPlusEnumerable.csproj", "{5F028056-DFEF-4BBC-B97A-A0F798A2D04E}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6B03B0CA-D532-4499-8E43-037AD9C62204}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{244D2533-BAC4-4F22-9C24-713F7A7AEDDB}"
 	ProjectSection(SolutionItems) = preProject
@@ -48,8 +41,5 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
 	EndGlobalSection
 EndGlobal

--- a/EPPlusEnumerable/EPPlusEnumerable.csproj
+++ b/EPPlusEnumerable/EPPlusEnumerable.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">.\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -59,13 +58,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EPPlusEnumerable/EPPlusEnumerable.csproj
+++ b/EPPlusEnumerable/EPPlusEnumerable.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Extensions.cs" />
     <Compile Include="Spreadsheet.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SpreadsheetExcludeFromOutputAttribute.cs" />
     <Compile Include="SpreadsheetTabNameAttribute.cs" />
     <Compile Include="SpreadsheetTableStyleAttribute.cs" />
     <Compile Include="SpreadsheetLinkAttribute.cs" />

--- a/EPPlusEnumerable/Spreadsheet.cs
+++ b/EPPlusEnumerable/Spreadsheet.cs
@@ -1,19 +1,21 @@
-﻿using OfficeOpenXml;
-using OfficeOpenXml.Table;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
-using System.Drawing;
-using System.Linq;
-using System.Reflection;
-
-namespace EPPlusEnumerable
+﻿namespace EPPlusEnumerable
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.ComponentModel.DataAnnotations;
+    using System.Drawing;
+    using System.Linq;
+    using System.Reflection;
+
+    using OfficeOpenXml;
+    using OfficeOpenXml.Table;
+
     public static class Spreadsheet
     {
         #region Static Fields
 
+        // ReSharper disable once InconsistentNaming
         private static readonly char[] _letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToArray();
 
         private const TableStyles DefaultTableStyle = TableStyles.Medium16;
@@ -23,60 +25,52 @@ namespace EPPlusEnumerable
         #region Public Methods
 
         /// <summary>
-        /// Creates an Excel spreadsheet with worksheets for each collection of objects.
+        ///     Creates an Excel spreadsheet with worksheets for each collection of objects.
         /// </summary>
-        /// <param name="data">A collection of data collections. Each outer collection will be used as a worksheet, while the inner collections will be used as data rows.</param>
+        /// <param name="data">
+        ///     A collection of data collections. Each outer collection will be used as a worksheet, while the inner
+        ///     collections will be used as data rows.
+        /// </param>
         /// <returns>An Excel spreadsheet as a byte array.</returns>
         public static byte[] Create(IEnumerable<IEnumerable<object>> data)
         {
             var package = new ExcelPackage();
-
-            foreach (var collection in data)
-            {
-                AddWorksheet(package, collection);
-            }
-
-            AddSpreadsheetLinks(package, data);
+            Spreadsheet.AddData(ref package, data);
 
             return package.GetAsByteArray();
         }
 
         /// <summary>
-        /// Creates an Excel spreadsheet with worksheets for each collection of objects.
+        ///     Creates an Excel spreadsheet with worksheets for each collection of objects.
         /// </summary>
-        /// <param name="data">A collection of data collections. Each outer collection will be used as a worksheet, while the inner collections will be used as data rows.</param>
+        /// <param name="data">
+        ///     A collection of data collections. Each outer collection will be used as a worksheet, while the inner
+        ///     collections will be used as data rows.
+        /// </param>
         /// <returns>A populated ExcelPackage object.</returns>
         public static ExcelPackage CreatePackage(IEnumerable<IEnumerable<object>> data)
         {
             var package = new ExcelPackage();
-
-            foreach (var collection in data)
-            {
-                AddWorksheet(package, collection);
-            }
-
-            AddSpreadsheetLinks(package, data);
+            Spreadsheet.AddData(ref package, data);
 
             return package;
         }
 
         /// <summary>
-        /// Creates an Excel spreadsheet with a single worksheet for the supplied data.
+        ///     Creates an Excel spreadsheet with a single worksheet for the supplied data.
         /// </summary>
         /// <param name="data">Each row of the spreadsheet will contain one item from the data collection.</param>
         /// <returns>An Excel spreadsheet as a byte array.</returns>
         public static byte[] Create(IEnumerable<object> data)
         {
             var package = new ExcelPackage();
-
-            AddWorksheet(package, data);
-            AddSpreadsheetLinks(package, new[] { data });
+            Spreadsheet.AddData(ref package, data);
 
             return package.GetAsByteArray();
         }
 
         /// <summary>
-        /// Creates an Excel spreadsheet with a single worksheet for the supplied data.
+        ///     Creates an Excel spreadsheet with a single worksheet for the supplied data.
         /// </summary>
         /// <param name="data">Each row of the spreadsheet will contain one item from the data collection.</param>
         /// <returns>A populated ExcelPackage object.</returns>
@@ -84,36 +78,70 @@ namespace EPPlusEnumerable
         {
             var package = new ExcelPackage();
 
-            AddWorksheet(package, data);
-            AddSpreadsheetLinks(package, new[] { data });
+            Spreadsheet.AddData(ref package, data);
 
             return package;
+        }
+
+        /// <summary>
+        ///     Adds a sinlge worksheet for the supplied data to the provided excel package.
+        /// </summary>
+        /// <param name="package">Existing ExcelPackage object.</param>
+        /// <param name="data">Each row of the added worksheet will contain one item from the data collection.</param>
+        public static void AddData(ref ExcelPackage package, IEnumerable<object> data)
+        {
+            IEnumerable<object> enumerable = data as IList<object> ?? data.ToList();
+
+            Spreadsheet.AddWorksheet(package, enumerable);
+            Spreadsheet.AddSpreadsheetLinks(package, new[] { enumerable });
+        }
+
+        /// <summary>
+        ///     Adds data to an Excel spreadsheet ExcelPackage with worksheets for each collection of objects.
+        /// </summary>
+        /// <param name="data">
+        ///     A collection of data collections. Each outer collection will be used as a worksheet, while the inner
+        ///     collections will be used as data rows.
+        /// </param>
+        /// <returns>A populated ExcelPackage object.</returns>
+        public static void AddData(ref ExcelPackage package, IEnumerable<IEnumerable<object>> data)
+        {
+            IEnumerable<IEnumerable<object>> collections = data as IList<IEnumerable<object>> ?? data.ToList();
+
+            foreach (IEnumerable<object> collection in collections)
+            {
+                Spreadsheet.AddWorksheet(package, collection);
+            }
+
+            Spreadsheet.AddSpreadsheetLinks(package, collections);
         }
 
         #endregion
 
         #region Private Methods
 
+        // ReSharper disable once UnusedMethodReturnValue.Local
         private static ExcelWorksheet AddWorksheet(ExcelPackage package, IEnumerable<object> data)
         {
-            if (data == null || !data.Any())
+            IEnumerable<object> enumerable = data as IList<object> ?? data.ToList();
+            if (data == null || !enumerable.Any())
             {
                 return null;
             }
 
-            string skipProperty = null;
-            var firstRow = data.First();
-            var collectionType = firstRow.GetType();
-            var properties = collectionType.GetProperties();
-            var worksheetName = GetWorksheetName(firstRow, collectionType, out skipProperty);
-            var worksheet = package.Workbook.Worksheets.Add(worksheetName);
+            string skipProperty;
+            object firstRow = enumerable.First();
+            Type collectionType = firstRow.GetType();
+            PropertyInfo[] properties = collectionType.GetProperties();
+            var worksheetName = Spreadsheet.GetWorksheetName(firstRow, collectionType, out skipProperty);
+            ExcelWorksheet worksheet = package.Workbook.Worksheets.Add(worksheetName);
             var col = 0;
 
             // add column headings
             for (var i = 0; i < properties.Count(); i++)
             {
-                var property = properties[i];
-                var propertyName = GetPropertyName(property);
+                PropertyInfo property = properties[i];
+                var propertyName = Spreadsheet.GetPropertyName(property);
 
                 if (skipProperty != null && property.Name.Equals(skipProperty))
                 {
@@ -121,18 +149,18 @@ namespace EPPlusEnumerable
                 }
 
                 col += 1;
-                worksheet.Cells[string.Format("{0}1", GetColumnLetter(col))].Value = propertyName;
+                worksheet.Cells[string.Format("{0}1", Spreadsheet.GetColumnLetter(col))].Value = propertyName;
             }
 
             // add rows (starting with two, since Excel is 1-based and we added a row of column headings)
-            for (var row = 2; row < data.Count() + 2; row++)
+            for (var row = 2; row < enumerable.Count() + 2; row++)
             {
-                var item = data.ElementAt(row - 2);
+                object item = enumerable.ElementAt(row - 2);
                 col = 0;
 
                 for (var i = 0; i < properties.Count(); i++)
                 {
-                    var property = properties.ElementAt(i);
+                    PropertyInfo property = properties.ElementAt(i);
 
                     if (skipProperty != null && property.Name.Equals(skipProperty))
                     {
@@ -142,19 +170,23 @@ namespace EPPlusEnumerable
                     }
 
                     col += 1;
-                    var cell = string.Format("{0}{1}", GetColumnLetter(col), row);
-                    var value = property.GetValue(item) ?? string.Empty;
-                    worksheet.Cells[cell].Value = GetPropertyValue(property, item);
+                    var cell = string.Format("{0}{1}", Spreadsheet.GetColumnLetter(col), row);
+
+                    object value = property.GetValue(item) ?? string.Empty;
+                    worksheet.Cells[cell].Value = Spreadsheet.GetPropertyValue(property, item);
                 }
             }
 
             // set table formatting
-            using (var range = worksheet.Cells[string.Format("A1:{0}{1}", GetColumnLetter(col), data.Count() + 1)])
+            using (
+                ExcelRange range =
+                    worksheet.Cells[string.Format("A1:{0}{1}", Spreadsheet.GetColumnLetter(col), enumerable.Count() + 1)
+                        ])
             {
                 range.AutoFitColumns();
 
-                var table = worksheet.Tables.Add(range, "table_" + worksheetName);
-                table.TableStyle = GetTableStyle(collectionType);
+                ExcelTable table = worksheet.Tables.Add(range, "table_" + worksheetName);
+                table.TableStyle = Spreadsheet.GetTableStyle(collectionType);
             }
 
             return worksheet;
@@ -173,14 +205,14 @@ namespace EPPlusEnumerable
                 worksheetName = worksheetName.Substring(0, worksheetName.IndexOf('_'));
             }
 
-            var worksheetNameProperty = collectionType
-                .GetProperties()
-                .FirstOrDefault(prop => Attribute.IsDefined(prop, typeof(SpreadsheetTabNameAttribute), true));
+            PropertyInfo worksheetNameProperty =
+                collectionType.GetProperties()
+                    .FirstOrDefault(prop => Attribute.IsDefined(prop, typeof(SpreadsheetTabNameAttribute), true));
 
             if (worksheetNameProperty != null)
             {
                 var worksheetNameAttribute = worksheetNameProperty.GetCustomAttribute<SpreadsheetTabNameAttribute>(true);
-                var worksheetPropertyValue = worksheetNameProperty.GetValue(firstRow);
+                object worksheetPropertyValue = worksheetNameProperty.GetValue(firstRow);
 
                 if (!string.IsNullOrWhiteSpace(worksheetNameAttribute.FormatString))
                 {
@@ -220,7 +252,7 @@ namespace EPPlusEnumerable
 
         private static TableStyles GetTableStyle(Type collectionType)
         {
-            var tableStyle = DefaultTableStyle;
+            TableStyles tableStyle = Spreadsheet.DefaultTableStyle;
 
             var spreadsheetTableStyleAttribute = collectionType.GetCustomAttribute<SpreadsheetTableStyleAttribute>(true);
             if (spreadsheetTableStyleAttribute != null)
@@ -254,7 +286,7 @@ namespace EPPlusEnumerable
 
         private static object GetPropertyValue(PropertyInfo property, object item)
         {
-            var inputValue = property.GetValue(item);
+            object inputValue = property.GetValue(item);
             object outputValue = string.Empty;
 
             var displayFormatAttribute = property.GetCustomAttribute<DisplayFormatAttribute>(true);
@@ -297,7 +329,7 @@ namespace EPPlusEnumerable
 
         private static void AddSpreadsheetLinks(ExcelPackage package, IEnumerable<IEnumerable<object>> data)
         {
-            foreach (var collection in data)
+            foreach (IEnumerable<object> collection in data)
             {
                 if (collection == null || !collection.Any())
                 {
@@ -305,11 +337,11 @@ namespace EPPlusEnumerable
                 }
 
                 string skipProperty = null;
-                var firstRow = collection.First();
-                var collectionType = firstRow.GetType();
-                var properties = collectionType.GetProperties();
-                var worksheetName = GetWorksheetName(firstRow, collectionType, out skipProperty);
-                var worksheet = package.Workbook.Worksheets[worksheetName];
+                object firstRow = collection.First();
+                Type collectionType = firstRow.GetType();
+                PropertyInfo[] properties = collectionType.GetProperties();
+                var worksheetName = Spreadsheet.GetWorksheetName(firstRow, collectionType, out skipProperty);
+                ExcelWorksheet worksheet = package.Workbook.Worksheets[worksheetName];
 
                 if (worksheet == null)
                 {
@@ -320,7 +352,7 @@ namespace EPPlusEnumerable
                 // and see if any have a SpreadsheetLinkAttribute specified
                 for (var prop = 1; prop <= properties.Count(); prop++)
                 {
-                    var property = properties.ElementAt(prop - 1);
+                    PropertyInfo property = properties.ElementAt(prop - 1);
 
                     if (skipProperty != null && property.Name.Equals(skipProperty))
                     {
@@ -339,7 +371,7 @@ namespace EPPlusEnumerable
                     }
 
                     // get the worksheet specified by the attribute
-                    var linkSheet = package.Workbook.Worksheets[attribute.WorksheetName];
+                    ExcelWorksheet linkSheet = package.Workbook.Worksheets[attribute.WorksheetName];
 
                     if (linkSheet == null)
                     {
@@ -355,7 +387,7 @@ namespace EPPlusEnumerable
                     // match the attribute's column header value
                     for (var col = 1; col <= linkSheet.Dimension.Columns; col++)
                     {
-                        var letter = GetColumnLetter(col);
+                        var letter = Spreadsheet.GetColumnLetter(col);
                         if (linkSheet.Cells[letter + "1"].Value.ToString().Equals(attribute.ColumnHeaderValue))
                         {
                             linkColumn = letter;
@@ -366,33 +398,43 @@ namespace EPPlusEnumerable
                     if (!string.IsNullOrWhiteSpace(linkColumn))
                     {
                         // we found the target column of the target worksheet, so we can add links!
-                        AddColumnLinks(worksheet, prop, linkSheet, linkColumn);
+                        Spreadsheet.AddColumnLinks(worksheet, prop, linkSheet, linkColumn);
                     }
                 }
             }
         }
 
-        private static void AddColumnLinks(ExcelWorksheet worksheet, int worksheetColumnIndex, ExcelWorksheet linkSheet, string linkColumn)
+        private static void AddColumnLinks(
+            ExcelWorksheet worksheet,
+            int worksheetColumnIndex,
+            ExcelWorksheet linkSheet,
+            string linkColumn)
         {
             // loop through the cells of the worksheet that correspond to the property
             // that had the SpreadsheetLinkAttribute and try to find a link target for each
             for (var worksheetRow = 1; worksheetRow <= worksheet.Dimension.Rows; worksheetRow++)
             {
-                var worksheetCell = worksheet.Cells[string.Format("{0}{1}", GetColumnLetter(worksheetColumnIndex), worksheetRow)];
+                ExcelRange worksheetCell =
+                    worksheet.Cells[
+                        string.Format("{0}{1}", Spreadsheet.GetColumnLetter(worksheetColumnIndex), worksheetRow)];
                 var worksheetValue = worksheetCell.Value.ToString();
 
                 // loop through the cells of the target worksheet column and see if any of the values
                 // match the value of the current worksheet cell
                 for (var linksheetRow = 1; linksheetRow <= linkSheet.Dimension.Rows; linksheetRow++)
                 {
-                    var linksheetValue = linkSheet.Cells[string.Format("{0}{1}", linkColumn, linksheetRow)].Value.ToString();
+                    var linksheetValue =
+                        linkSheet.Cells[string.Format("{0}{1}", linkColumn, linksheetRow)].Value.ToString();
 
                     if (worksheetValue.Equals(linksheetValue))
                     {
                         // we found a match! this is the link target,
                         // so add the hyperlink to the worksheet cell
                         // and stop searching for targets for this row
-                        worksheetCell.Hyperlink = new ExcelHyperLink(string.Format("'{0}'!{1}{2}", linkSheet.Name, linkColumn, linksheetRow), worksheetValue.ToString());
+                        worksheetCell.Hyperlink =
+                            new ExcelHyperLink(
+                                string.Format("'{0}'!{1}{2}", linkSheet.Name, linkColumn, linksheetRow),
+                                worksheetValue);
                         worksheetCell.Style.Font.UnderLine = true;
                         worksheetCell.Style.Font.Color.SetColor(Color.Blue);
                         break;
@@ -402,25 +444,25 @@ namespace EPPlusEnumerable
         }
 
         /// <summary>
-        /// Gets the Excel-style column letter for the specified numerical index (e.g. 4 is D, 26 is Z, 27 is AA, 28 is AB...).
+        ///     Gets the Excel-style column letter for the specified numerical index (e.g. 4 is D, 26 is Z, 27 is AA, 28 is AB...).
         /// </summary>
         /// <param name="column">The numerical index of the column.</param>
         /// <returns>The corresponding Excel-style column letter.</returns>
         private static string GetColumnLetter(int column)
         {
-            if (column <= _letters.Length)
+            if (column <= Spreadsheet._letters.Length)
             {
-                return _letters[column - 1].ToString();
+                return Spreadsheet._letters[column - 1].ToString();
             }
 
             var number = column;
-            string letter = string.Empty;
+            var letter = string.Empty;
 
             while (number > 0)
             {
-                var remainder = (number - 1) % _letters.Length;
-                letter = _letters[remainder] + letter;
-                number = (number - remainder) / _letters.Length;
+                var remainder = (number - 1) % Spreadsheet._letters.Length;
+                letter = Spreadsheet._letters[remainder] + letter;
+                number = (number - remainder) / Spreadsheet._letters.Length;
             }
 
             return letter;

--- a/EPPlusEnumerable/SpreadsheetExcludeFromOutputAttribute.cs
+++ b/EPPlusEnumerable/SpreadsheetExcludeFromOutputAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace EPPlusEnumerable
+{
+    using System;
+
+    /// <summary>
+    /// Use this attribute to denote that the property is not used to create a column in an excel worksheet when exporting data.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property,AllowMultiple = false,Inherited = true)]
+    public class SpreadsheetExcludeFromOutputAttribute : Attribute
+    {   
+    }
+}

--- a/SampleConsoleApp/Program.cs
+++ b/SampleConsoleApp/Program.cs
@@ -41,6 +41,7 @@ namespace SampleConsoleApp
 
         public string Country { get; set; }
 
+        [SpreadsheetExcludeFromOutput]
         public string Zip { get; set; }
     }
 
@@ -59,5 +60,8 @@ namespace SampleConsoleApp
 
         [SpreadsheetTabName(FormatString = "{0:MMMM yyyy}")]
         public DateTime Date { get; set; }
+
+        [SpreadsheetExcludeFromOutput]
+        public Guid GarbageData { get; set; }
     }
 }

--- a/SampleConsoleApp/SampleConsoleApp.csproj
+++ b/SampleConsoleApp/SampleConsoleApp.csproj
@@ -103,13 +103,6 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SampleConsoleApp/SampleDataContext.cs
+++ b/SampleConsoleApp/SampleDataContext.cs
@@ -50,7 +50,8 @@ namespace SampleConsoleApp
                             Number = order.OrderID,
                             Date = order.OrderDate.Value,
                             Item = order.Order_Details.First().Product.ProductName,
-                            Price = order.Order_Details.First().UnitPrice
+                            Price = order.Order_Details.First().UnitPrice,
+                            GarbageData = Guid.NewGuid()
                         });
                     }
                 }


### PR DESCRIPTION
See: #12 , #10 

This pull request is initially just a request for review, I don't fully expect it to be merged in straight away,  rather after some discussion and fixes on my part; I'd appreciate if it happens though : )

Covered changes

 * Add [SpreadsheetExcludeFromOutput] attribute. This works along the ExcludeFromOutput fllag in tabnames for now. Ideally I feel TabName and Exclude attributes should be used separately to follow SRP, also "cohesion, not coupling" (so that the exclude flag should be dropped from name attribute if we are actually to include my suggested changes in the library
 * update the solution to VS 2015, might need revert - depends on further decision by @bradwestness 
 * refactor the code a little to deduplicate logic for passing IEnumerables to work sheets
 * allow adding data to existing excel packages through AddData(ref ExcelPackage package, IEnumerable ...). One might question the *ref* usage, decided on this to make sure that implementors and clients are aware that passed excel package is being changed after all.
 * add unit test for exclude from output, refactor unit tests a little.