### PR TITLE
Support for MetadataTypes

### DIFF
--- a/EPPlusEnumerable/Extensions.cs
+++ b/EPPlusEnumerable/Extensions.cs
@@ -5,14 +5,28 @@
 
     internal static class Extensions
     {
-        public static T GetCustomAttribute<T>(this MemberInfo element, bool inherit) where T : Attribute
+        public static T GetCustomAttribute<T>(this MemberInfo element, Type type, bool inherit) where T : Attribute
         {
-            return (T)Attribute.GetCustomAttribute(element, typeof(T), inherit);
+            var attr = (T)Attribute.GetCustomAttribute(element, typeof(T), inherit);
+            
+            if (attr == null)
+            {
+                return element.GetMetaAttribute<T>(type, inherit);
+            }
+            
+            return attr;
         }
 
-        public static T GetCustomAttribute<T>(this MemberInfo element) where T : Attribute
+        public static T GetCustomAttribute<T>(this MemberInfo element, Type type) where T : Attribute
         {
-            return (T)Attribute.GetCustomAttribute(element, typeof(T));
+            var attr = (T)Attribute.GetCustomAttribute(element, typeof(T));
+            
+            if (attr == null)
+            {
+                return element.GetMetaAttribute<T>(type);
+            }
+            
+            return attr;
         }
 
         public static object GetValue(this PropertyInfo element, Object obj)

--- a/EPPlusEnumerable/Extensions.cs
+++ b/EPPlusEnumerable/Extensions.cs
@@ -1,33 +1,33 @@
-﻿namespace EPPlusEnumerable
-{
-    using System;
-    using System.ComponentModel.DataAnnotations;
-    using System.Linq;
-    using System.Reflection;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
 
+namespace EPPlusEnumerable
+{
     internal static class Extensions
     {
         public static T GetCustomAttribute<T>(this MemberInfo element, Type type, bool inherit) where T : Attribute
         {
             var attr = (T)Attribute.GetCustomAttribute(element, typeof(T), inherit);
-            
+
             if (attr == null)
             {
                 return element.GetMetaAttribute<T>(type, inherit);
             }
-            
+
             return attr;
         }
 
         public static T GetCustomAttribute<T>(this MemberInfo element, Type type) where T : Attribute
         {
             var attr = (T)Attribute.GetCustomAttribute(element, typeof(T));
-            
+
             if (attr == null)
             {
                 return element.GetMetaAttribute<T>(type);
             }
-            
+
             return attr;
         }
 
@@ -35,7 +35,7 @@
         {
             return element.GetValue(obj, BindingFlags.Default, null, null, null);
         }
-        
+
         /// <summary>
         /// Crawls up the parent class to find any MetadaType to search for attributes as well.
         /// </summary>
@@ -54,16 +54,16 @@
                 .FirstOrDefault();
 
             // Check for null to avoid too much reflection
-            if(metaTypeAttrs != null)
+            if (metaTypeAttrs != null)
             {
                 // Get the MetadataClass to check for attributes on
                 var metaType = metaTypeAttrs.MetadataClassType;
                 // Find the current element in the MetadataClass
                 var metaElement = metaType?.GetMember(element.Name).FirstOrDefault();
-                
-                metaAttr = metaElement?.GetCustomAttribute<T>(inherit)
+
+                metaAttr = metaElement?.GetCustomAttribute<T>(metaType, inherit);
             }
-            
+
             return metaAttr;
         }
     }

--- a/EPPlusEnumerable/Extensions.cs
+++ b/EPPlusEnumerable/Extensions.cs
@@ -1,6 +1,8 @@
 ﻿namespace EPPlusEnumerable
 {
     using System;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
     using System.Reflection;
 
     internal static class Extensions

--- a/EPPlusEnumerable/Extensions.cs
+++ b/EPPlusEnumerable/Extensions.cs
@@ -33,5 +33,36 @@
         {
             return element.GetValue(obj, BindingFlags.Default, null, null, null);
         }
+        
+        /// <summary>
+        /// Crawls up the parent class to find any MetadaType to search for attributes as well.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="element">The property we're searchign for attributes on</param>
+        /// <param name="type">The parent type of the property</param>
+        /// <param name="inherit"></param>
+        /// <returns></returns>
+        public static T GetMetaAttribute<T>(this MemberInfo element, Type type, bool inherit = true) where T : Attribute
+        {
+            T metaAttr = null;
+            // Get the MetadataType Attribute from the parent class
+            var metaTypeAttrs = (MetadataTypeAttribute)type
+                .GetCustomAttributes(typeof(MetadataTypeAttribute), inherit)
+                .OfType<MetadataTypeAttribute>()
+                .FirstOrDefault();
+
+            // Check for null to avoid too much reflection
+            if(metaTypeAttrs != null)
+            {
+                // Get the MetadataClass to check for attributes on
+                var metaType = metaTypeAttrs.MetadataClassType;
+                // Find the current element in the MetadataClass
+                var metaElement = metaType?.GetMember(element.Name).FirstOrDefault();
+                
+                metaAttr = metaElement?.GetCustomAttribute<T>(inherit)
+            }
+            
+            return metaAttr;
+        }
     }
 }

--- a/EPPlusEnumerable/Spreadsheet.cs
+++ b/EPPlusEnumerable/Spreadsheet.cs
@@ -1,4 +1,4 @@
-﻿using OfficeOpenXml;
+using OfficeOpenXml;
 using OfficeOpenXml.Table;
 using System;
 using System.Collections.Generic;
@@ -112,9 +112,9 @@ namespace EPPlusEnumerable
             for (var i = 0; i < properties.Count(); i++)
             {
                 var property = properties[i];
-                var propertyName = GetPropertyName(property);
+                var propertyName = GetPropertyName(property, collectionType);
 
-                if (property.GetCustomAttribute<SpreadsheetExcludeAttribute>() != null)
+                if (property.GetCustomAttribute<SpreadsheetExcludeAttribute>(collectionType) != null)
                 {
                     // this property has a SpreadsheetExcludeAttribute
                     continue;
@@ -134,7 +134,7 @@ namespace EPPlusEnumerable
                 {
                     var property = properties.ElementAt(i);
 
-                    if (property.GetCustomAttribute<SpreadsheetExcludeAttribute>() != null)
+                    if (property.GetCustomAttribute<SpreadsheetExcludeAttribute>(collectionType) != null)
                     {
                         continue;
                     }
@@ -176,7 +176,7 @@ namespace EPPlusEnumerable
 
             if (worksheetNameProperty != null)
             {
-                var worksheetNameAttribute = worksheetNameProperty.GetCustomAttribute<SpreadsheetTabNameAttribute>(true);
+                var worksheetNameAttribute = worksheetNameProperty.GetCustomAttribute<SpreadsheetTabNameAttribute>(collectionType, true);
                 var worksheetPropertyValue = worksheetNameProperty.GetValue(firstRow);
 
                 if (!string.IsNullOrWhiteSpace(worksheetNameAttribute.FormatString))
@@ -190,14 +190,14 @@ namespace EPPlusEnumerable
             }
             else
             {
-                var displayNameAttribute = collectionType.GetCustomAttribute<DisplayNameAttribute>(true);
+                var displayNameAttribute = collectionType.GetCustomAttribute<DisplayNameAttribute>(collectionType, true);
                 if (displayNameAttribute != null)
                 {
                     worksheetName = displayNameAttribute.DisplayName;
                 }
                 else
                 {
-                    var displayAttribute = collectionType.GetCustomAttribute<DisplayAttribute>(true);
+                    var displayAttribute = collectionType.GetCustomAttribute<DisplayAttribute>(collectionType, true);
                     if (displayAttribute != null)
                     {
                         worksheetName = displayAttribute.Name;
@@ -212,7 +212,7 @@ namespace EPPlusEnumerable
         {
             var tableStyle = DefaultTableStyle;
 
-            var spreadsheetTableStyleAttribute = collectionType.GetCustomAttribute<SpreadsheetTableStyleAttribute>(true);
+            var spreadsheetTableStyleAttribute = collectionType.GetCustomAttribute<SpreadsheetTableStyleAttribute>(collectionType, true);
             if (spreadsheetTableStyleAttribute != null)
             {
                 tableStyle = spreadsheetTableStyleAttribute.TableStyle;
@@ -221,18 +221,18 @@ namespace EPPlusEnumerable
             return tableStyle;
         }
 
-        private static string GetPropertyName(PropertyInfo property)
+        private static string GetPropertyName(PropertyInfo property, Type collectionType)
         {
             var propertyName = property.Name;
 
-            var displayNameAttribute = property.GetCustomAttribute<DisplayNameAttribute>(true);
+            var displayNameAttribute = property.GetCustomAttribute<DisplayNameAttribute>(collectionType, true);
             if (displayNameAttribute != null)
             {
                 propertyName = displayNameAttribute.DisplayName;
             }
             else
             {
-                var displayAttribute = property.GetCustomAttribute<DisplayAttribute>(true);
+                var displayAttribute = property.GetCustomAttribute<DisplayAttribute>(collectionType, true);
                 if (displayAttribute != null)
                 {
                     propertyName = displayAttribute.Name;
@@ -247,7 +247,7 @@ namespace EPPlusEnumerable
             var inputValue = property.GetValue(item);
             object outputValue = string.Empty;
 
-            var displayFormatAttribute = property.GetCustomAttribute<DisplayFormatAttribute>(true);
+            var displayFormatAttribute = property.GetCustomAttribute<DisplayFormatAttribute>(item.GetType(), true);
             if (displayFormatAttribute != null)
             {
                 if (inputValue == null && !string.IsNullOrWhiteSpace(displayFormatAttribute.NullDisplayText))
@@ -311,12 +311,12 @@ namespace EPPlusEnumerable
                 {
                     var property = properties.ElementAt(prop - 1);
 
-                    if (property.GetCustomAttribute<SpreadsheetExcludeAttribute>() != null)
+                    if (property.GetCustomAttribute<SpreadsheetExcludeAttribute>(collectionType) != null)
                     {
                         continue;
                     }
 
-                    var attribute = property.GetCustomAttribute<SpreadsheetLinkAttribute>();
+                    var attribute = property.GetCustomAttribute<SpreadsheetLinkAttribute>(collectionType);
 
                     if (attribute == null)
                     {

--- a/EPPlusEnumerable/Spreadsheet.cs
+++ b/EPPlusEnumerable/Spreadsheet.cs
@@ -138,18 +138,18 @@ namespace EPPlusEnumerable
                     {
                         continue;
                     }
-                                        
+
                     col += 1;
                     var cell = string.Format("{0}{1}", GetColumnLetter(col), row);
 
-                    var cellStyleAttribute = property.GetCustomAttribute<SpreadsheetCellStyleAttribute>();
+                    var cellStyleAttribute = property.GetCustomAttribute<SpreadsheetCellStyleAttribute>(collectionType);
                     if (cellStyleAttribute != null)
                     {
                         cellStyleAttribute.ApplyCellStyles(worksheet.Cells[cell]);
                     }
 
                     var value = property.GetValue(item) ?? string.Empty;
-                    worksheet.Cells[cell].Value = GetPropertyValue(property, item);                    
+                    worksheet.Cells[cell].Value = GetPropertyValue(property, item);
                 }
             }
 

--- a/EPPlusEnumerable/SpreadsheetExcludeAttribute.cs
+++ b/EPPlusEnumerable/SpreadsheetExcludeAttribute.cs
@@ -6,7 +6,7 @@ namespace EPPlusEnumerable
     /// Use this attribute to denote that the property is to be excluded and not outputted in the Excel worksheet.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class SpreadsheetExcludeAttribute: Attribute
+    public class SpreadsheetExcludeAttribute : Attribute
     {
         #region Constructors
 

--- a/SampleConsoleApp/Program.cs
+++ b/SampleConsoleApp/Program.cs
@@ -46,9 +46,10 @@ namespace SampleConsoleApp
 
         public string Zip { get; set; }
     }
-
+    
+    [MetadataType(typeof(OrdersMetadata))]
     [DisplayName("Orders"), SpreadsheetTableStyle(TableStyles.Medium16)]
-    public class Order
+    public partial class Order
     {
         public int Number { get; set; }
 
@@ -62,5 +63,16 @@ namespace SampleConsoleApp
 
         [SpreadsheetTabName(FormatString = "{0:MMMM yyyy}")]
         public DateTime Date { get; set; }
+    }
+    
+    // Metadata class for Orders. The new GetMetaAttribute extension method will find this and crawl it for attributes.
+    public class OrdersMetadata
+    {
+        [Display(Name = "Order #")]
+        public int Number { get; set; }
+        [DisplayName("Item Price")]
+        public decimal Price { get; set; }
+        [DisplayName("Customer Name")]
+        public string Customer { get; set; }
     }
 }


### PR DESCRIPTION
Added new `GetMetaAttribute` extension method to traverse parent class, locate any `MetadataTypeAttribute`, and crawl the located class for attributes. Updated method calls to support taking in base class type, updated using statements where necessary, added new metadata class for testing.